### PR TITLE
Include algorithm header in model_impl.h

### DIFF
--- a/src/core/model_impl.h
+++ b/src/core/model_impl.h
@@ -21,6 +21,8 @@
 
 #include <opc/ua/model.h>
 
+#include <algorithm>
+
 namespace OpcUa
 {
 namespace Model


### PR DESCRIPTION
With newer versions of GCC, the error: ‘for_each’ is not a member of ‘std’
is triggered unless the algorithm header from std lib is included.